### PR TITLE
Replace ST_TIFF with ST_DUMP

### DIFF
--- a/api/services/data_fetch.py
+++ b/api/services/data_fetch.py
@@ -4,6 +4,7 @@ Writes GeoTIFFs (rasters) and GeoJSON files (vectors) into the work directory
 for the wasm-connectivity resistance-pipeline binary to consume.
 """
 
+import io
 import json
 import logging
 import os
@@ -74,11 +75,11 @@ def _fetch_raster_as_tiff(conn, table, xmin, ymin, xmax, ymax, ncols, nrows):
         cur.execute(
             pgsql.SQL(
                 """
-                SELECT ST_AsTIFF(
+                SELECT ST_DumpValues(
                     ST_Resample(
                         ST_Union(ST_Clip(rast, geom)),
                         %s, %s
-                    )
+                    ), 1
                 )
                 FROM {},
                      (SELECT ST_MakeEnvelope(%s, %s, %s, %s, 27700) AS geom) AS t2
@@ -90,7 +91,32 @@ def _fetch_raster_as_tiff(conn, table, xmin, ymin, xmax, ymax, ncols, nrows):
         row = cur.fetchone()
         if row is None or row[0] is None:
             return None
-        return bytes(row[0])
+
+        vals = row[0]
+        if isinstance(vals, str):
+            logger.warning(
+                "ST_DumpValues returned a string; parsing as literal array"
+            )
+            vals = json.loads(vals.replace("{", "[").replace("}", "]"))
+
+        arr = np.array(vals, dtype=np.float32)
+
+        if arr.shape != (nrows, ncols):
+            logger.warning(
+                "ST_DumpValues returned shape %s, expected (%d, %d)",
+                arr.shape, nrows, ncols,
+            )
+            arr = np.zeros((nrows, ncols), dtype=np.float32)
+
+        transform = from_bounds(xmin, ymin, xmax, ymax, ncols, nrows)
+        buf = io.BytesIO()
+        with rasterio.open(
+            buf, "w", driver="GTiff", height=nrows, width=ncols,
+            count=1, dtype=np.float32, crs="EPSG:27700",
+            transform=transform, nodata=-9999.0,
+        ) as dst:
+            dst.write(arr, 1)
+        return buf.getvalue()
     finally:
         cur.close()
 

--- a/api/services/data_fetch.py
+++ b/api/services/data_fetch.py
@@ -75,15 +75,22 @@ def _fetch_raster_as_tiff(conn, table, xmin, ymin, xmax, ymax, ncols, nrows):
         cur.execute(
             pgsql.SQL(
                 """
-                SELECT ST_DumpValues(
-                    ST_Resample(
+                WITH resampled AS (
+                    SELECT ST_Resample(
                         ST_Union(ST_Clip(rast, geom)),
                         %s, %s
-                    ), 1
+                    ) AS rast
+                    FROM {},
+                         (SELECT ST_MakeEnvelope(%s, %s, %s, %s, 27700) AS geom) AS t2
+                    WHERE tile_extent && t2.geom
                 )
-                FROM {},
-                     (SELECT ST_MakeEnvelope(%s, %s, %s, %s, 27700) AS geom) AS t2
-                WHERE tile_extent && t2.geom
+                SELECT
+                    ST_DumpValues(rast, 1),
+                    ST_XMin(ST_Envelope(rast)),
+                    ST_YMin(ST_Envelope(rast)),
+                    ST_XMax(ST_Envelope(rast)),
+                    ST_YMax(ST_Envelope(rast))
+                FROM resampled
                 """
             ).format(pgsql.Identifier(table)),
             (ncols, nrows, xmin, ymin, xmax, ymax),
@@ -92,11 +99,9 @@ def _fetch_raster_as_tiff(conn, table, xmin, ymin, xmax, ymax, ncols, nrows):
         if row is None or row[0] is None:
             return None
 
-        vals = row[0]
+        vals, rxmin, rymin, rxmax, rymax = row
+
         if isinstance(vals, str):
-            logger.warning(
-                "ST_DumpValues returned a string; parsing as literal array"
-            )
             vals = json.loads(vals.replace("{", "[").replace("}", "]"))
 
         arr = np.array(vals, dtype=np.float32)
@@ -108,7 +113,7 @@ def _fetch_raster_as_tiff(conn, table, xmin, ymin, xmax, ymax, ncols, nrows):
             )
             arr = np.zeros((nrows, ncols), dtype=np.float32)
 
-        transform = from_bounds(xmin, ymin, xmax, ymax, ncols, nrows)
+        transform = from_bounds(rxmin, rymin, rxmax, rymax, ncols, nrows)
         buf = io.BytesIO()
         with rasterio.open(
             buf, "w", driver="GTiff", height=nrows, width=ncols,

--- a/docker/Dockerfile.frontend.builder
+++ b/docker/Dockerfile.frontend.builder
@@ -1,0 +1,16 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    pkg-config \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+WORKDIR /app
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,23 @@
-docker run --rm -v "$(pwd)/frontend/gsbio-engine":/app -w /app node:lts sh -c "npm install && npm run build"
-docker run --rm -v "$(pwd)/frontend":/app -w /app node:lts sh -c "npm install && npm run build"
+docker build -f docker/Dockerfile.frontend.builder -t frontend-builder:latest .
+
+docker run --rm \
+  -v "$(pwd)":/app \
+  -w /app/frontend/wasm-connectivity \
+  frontend-builder:latest \
+  wasm-pack build --target web --out-dir lib
+
+docker run --rm \
+  -v "$(pwd)":/app \
+  -w /app/frontend/gsbio-engine \
+  frontend-builder:latest \
+  sh -c "npm install && npm run build"
+
+docker run --rm \
+  -v "$(pwd)":/app \
+  -w /app/frontend \
+  frontend-builder:latest \
+  sh -c "npm install && npm run build"
+
 docker build --network=host -t dispersion-prediction-app-frontend -f docker/Dockerfile.frontend . --build-context gsbio=./frontend/gsbio-engine
 docker build -t dispersion-prediction-app-api -f docker/Dockerfile.backend .
 docker build -t dispersion-prediction-app-postgis -f docker/Dockerfile.gis .


### PR DESCRIPTION
- ST_TIFF requires configuration we don't always have permission for
- ST_DUMP works for more postgres deployments.